### PR TITLE
configure code coverage with sonarcloud.io

### DIFF
--- a/.github/workflows/build-and-publish-coverage.yml
+++ b/.github/workflows/build-and-publish-coverage.yml
@@ -1,0 +1,45 @@
+#################################################################
+# Security Scanner using SonarQube
+## compile code
+## publish scan results to Sonar Cloud
+## displays results in the PR or checks section
+###############################################################
+
+name: build-and-publish-to-sonar-cloud
+on:  # Triggers the workflow on push or pull request events
+  push:
+    branches:
+      # only for master branch
+      - master
+  pull_request:
+    # only for master and test-github-actions branches
+    types: [opened, synchronize, reopened]
+jobs:
+  build-and-publish:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Cache SonarCloud packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+      - name: Cache Maven packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Build and analyze
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=asalan316_spring-boot-camunda-bpm-example

--- a/.github/workflows/sonar-scanner-with-sonar-cloud.yml
+++ b/.github/workflows/sonar-scanner-with-sonar-cloud.yml
@@ -1,0 +1,29 @@
+name: "Publish Code Coverage Results on Sonar Cloud"
+on:   # Triggers the workflow on push or pull request events
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [opened, synchronize, reopened]
+jobs:
+  SonarTrigger:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+
+      - name: Build simple java app with maven
+        run: mvn -B package --file pom.xml
+
+      - name: Publish Sonar Scan Result on SonarCloud.io
+        uses: asalan316/sonarcloud-github-action
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/sonar-scanner.yml
+++ b/.github/workflows/sonar-scanner.yml
@@ -7,7 +7,7 @@
 
 env:
   # sonarqube server URL
-  SONARQUBE_LOGIN: {{secret.}}                  # default sonarqube username
+  SONARQUBE_LOGIN: admin                # default sonarqube username
   SONARQUBE_PASSWORD: admin               # default sonarqube password
 
 name: Security Scanner

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,9 @@
         <camunda.spring-boot.version>7.14.0</camunda.spring-boot.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <jacoco.version>0.8.7</jacoco.version>
+        <sonar.organization>asalan316</sonar.organization>
+        <sonar.host.url>https://sonarcloud.io</sonar.host.url>
     </properties>
     <dependencies>
         <dependency>
@@ -65,6 +68,12 @@
             <artifactId>httpclient</artifactId>
             <version>4.3.6</version>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/org.jacoco/jacoco-maven-plugin -->
+        <dependency>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
+            <version>${jacoco.version}</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -79,6 +88,25 @@
                     <execution>
                         <goals>
                             <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco.version}</version>
+                <executions>
+                    <execution>
+                        <id>agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                       <goals>
+                            <goal>report</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,17 @@
+# must be unique in a given SonarQube instance
+sonar.projectKey=asalan316_spring-boot-camunda-bpm-example
+sonar.organization=asalan316
+#sonar.test.inclusions=autoscaler/**/*_test.go, scheduler/src/test/
+#################################################
+#   JAVA Sources
+#################################################
+sonar.java.binaries=scheduler/target/classes
+#################################################
+#   EXCLUSIONS if any
+#################################################
+# sonar.exclusions=*.js,**/*.css,**/*.yml,**/*.yaml,**/pom.xml,**/*.json
+#################################################
+#   Code Coverage Data
+#################################################
+#sonar.tests=scheduler/src/test/java,src/autoscaler/**/*_test.go
+sonar.coverage.jacoco.xmlReportPaths=scheduler/target/site/jacoco/jacoco.xml

--- a/src/main/java/com/ak/bpm/Credentials.java
+++ b/src/main/java/com/ak/bpm/Credentials.java
@@ -1,0 +1,18 @@
+package com.ak.bpm;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class Credentials {
+
+    private static final String PASSWORD = "password123";
+    private static final String USERNAME = "admin";
+
+    public String getPASSWORD() {
+        return PASSWORD;
+    }
+
+    public String getUSERNAME() {
+        return USERNAME;
+    }
+}

--- a/src/main/java/com/ak/bpm/SampleApprovalApplication.java
+++ b/src/main/java/com/ak/bpm/SampleApprovalApplication.java
@@ -37,6 +37,9 @@ public class SampleApprovalApplication {
     @Autowired
     private TaskService taskService;
 
+    @Autowired
+    private Credentials credentials;
+
 
     public static void main(String[] args) {
         ConfigurableApplicationContext ctx = SpringApplication.run(SampleApprovalApplication.class, args);
@@ -45,6 +48,8 @@ public class SampleApprovalApplication {
 
     @EventListener
     private void processPostDeploy(PostDeployEvent event) {
+        logger.info("username "+ credentials.getUSERNAME());
+        logger.info("password "+ credentials.getPASSWORD());
 
         String processInstanceId = runtimeService.startProcessInstanceByKey("sample-approval").getProcessInstanceId();
         logger.info("started instance sample");
@@ -118,5 +123,10 @@ public class SampleApprovalApplication {
                         .list();
 
         return processInstances.get(0);
+    }
+
+    public String printMessage(String message){
+        StringBuilder builder = new StringBuilder("hello");
+        return builder.append(message).toString();
     }
 }

--- a/src/main/java/com/ak/bpm/SendNotificationsDelegate.java
+++ b/src/main/java/com/ak/bpm/SendNotificationsDelegate.java
@@ -5,6 +5,9 @@ import org.camunda.bpm.engine.delegate.JavaDelegate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
+import java.util.Map;
+
+import java.util.HashMap;
 
 /**
  *  External class triggered from Send Notification Activity
@@ -13,10 +16,13 @@ import org.springframework.stereotype.Component;
 public class SendNotificationsDelegate implements JavaDelegate {
 
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
+    Map<String, Object> storage = new HashMap<>();
 
     @Override
     public void execute(DelegateExecution execution) {
         logger.info("executing task send notifications : " + execution);
+        storage.computeIfAbsent("eventName", k -> execution.getEventName() );
+        logger.info("storage contains: "+ storage.toString() );
         logger.info("completed task: {}", execution.getCurrentActivityName());
     }
 

--- a/src/test/java/com/ak/bpm/CredentialsTest.java
+++ b/src/test/java/com/ak/bpm/CredentialsTest.java
@@ -1,0 +1,25 @@
+package com.ak.bpm;
+
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.Assert.*;
+
+@SpringBootTest
+public class CredentialsTest {
+
+    @Autowired
+    private Credentials credentials;
+
+    @Test
+    public void testPASSWORD_isNotEmpty() {
+        assertThat(credentials.getPASSWORD()).isNotNull();
+
+    }
+
+    @Test
+    public void getUSERNAME() {
+    }
+}


### PR DESCRIPTION
**Problem/Feature**

As a developer, I am looking to improve my code quality and wants to receive fast feedback for my code changes. Specially, when a change comes in the Pull Request (PR) which can be overlooked. In such cases, automated static code analysis can be helpful, which list code coverage, potential bugs, code smells, vulnerabilities and security issues in the form of reports.

One popular tool, SonarCloud by SonarSource helped me to detect bugs and list code coverage detail on the PR. In the workflow, I have used an existing Github Action from sonar cloud to automatically analysis my changes (in a PR) and post the results on the PR itself.

GitHub Action used [https://github.com/SonarSource/sonarcloud-github-action]

This example change uses [SonarCloud Github Action ](https://github.com/SonarSource/sonarcloud-github-action) to provide feedback to the developer directly on the Pull Request. It does the following:

 - create Github Action for Java Application
 - Build the project
 - uses SonarCloud Action 
   - publish test coverage results (using jacoco maven plugin)
   - reports potential bugs/ code vulnerabilities and code smells